### PR TITLE
fix(assess): fix quality code range

### DIFF
--- a/src/utils/assess.ts
+++ b/src/utils/assess.ts
@@ -187,7 +187,7 @@ export function getQualityCode(quality: number, level: number) {
     return level - 4
   }
   // compatible with values > 200
-  if (quality > 170) {
+  if (quality >= 170) {
     return 6
   }
   if (inRange(quality, 140, 170)) {


### PR DESCRIPTION
This fixes issue #42 by including the quality 170 in the ornate quality code range.